### PR TITLE
Add DNS config to static interfaces

### DIFF
--- a/templates/guests/debian/network_static.erb
+++ b/templates/guests/debian/network_static.erb
@@ -7,4 +7,10 @@ iface <%= options[:device] %> inet static
 <% if options[:gateway] %>
       gateway <%= options[:gateway] %>
 <% end %>
+<% if options[:dns_nameserver] %>
+      dns-nameservers <%= options[:dns_nameserver] %>
+<% end %>
+<% if options[:dns_search] %>
+      dns-search <%= options[:dns_search] %>
+<% end %>
 #VAGRANT-END


### PR DESCRIPTION
Add a couple parameters to enable specifying the DNS nameservers and search domains in /etc/network/interfaces.
It looks like a bridged public_network connection (at least on providers like libvirt/kvm) could use some more control on the network interface configuration. Though other parameters might apply that can be manually configured in /etc/network/interfaces, at least the two DNS related parameters look very much needed.